### PR TITLE
Remove tick delay from structure pasting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/main/java/com/playmonumenta/structures/StructuresAPI.java
+++ b/src/main/java/com/playmonumenta/structures/StructuresAPI.java
@@ -450,10 +450,8 @@ public class StructuresAPI {
 
 								if (newBlockType == null || !newBlockType.equals(BlockTypes.STRUCTURE_VOID)) {
 									// This position is not in structure void in the clipboard
-									if (!noLoadPositions.contains(compressToLong(position.getBlockX(), position.getBlockY(), position.getBlockZ()))) {
-										// This position is not in the list of blocks that should not be overwritten
-										return true;
-									}
+									// This position is not in the list of blocks that should not be overwritten
+									return !noLoadPositions.contains(compressToLong(position.getBlockX(), position.getBlockY(), position.getBlockZ()));
 								}
 
 								// Don't overwrite by default
@@ -470,13 +468,13 @@ public class StructuresAPI {
 						MSLog.finer(() -> "Loading structure took " + (System.currentTimeMillis() - pasteTime) + " milliseconds (async)"); // STOP -->
 
 						/* Add a 5 tick delay until the next task for shifting */
-						Bukkit.getScheduler().runTaskLater(plugin, () -> signal.complete(null), 5);
+						Bukkit.getScheduler().runTaskLater(plugin, () -> signal.complete(null), 0);
 
 						/* 6s later, signal caller that loading is complete */
-						Bukkit.getScheduler().runTaskLater(plugin, () -> future.complete(null), 120);
+						Bukkit.getScheduler().runTaskLater(plugin, () -> future.complete(null), 0);
 
 						/* 10s later, unmark all chunks as force loaded */
-						Bukkit.getScheduler().runTaskLater(plugin, () -> unmarkChunksAsync(world, shiftedRegion), 200);
+						Bukkit.getScheduler().runTaskLater(plugin, () -> unmarkChunksAsync(world, shiftedRegion), 0);
 
 					});
 				}


### PR DESCRIPTION
Root cause has been fixed, so unless these delays are needed for another reason, I will remove them.

More cleanup can probably be done, but for now this speeds up shifting generation significantly.